### PR TITLE
Addressed ModuleNotFoundError for STOPS_LIST import from cltk.stop.latin

### DIFF
--- a/3 Basic NLP.ipynb
+++ b/3 Basic NLP.ipynb
@@ -995,7 +995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -1011,7 +1011,7 @@
     "\n",
     "# The easiest way to do this in Python is to use a list comprehension to remove stopwords\n",
     "\n",
-    "from cltk.stop.latin.stops import STOPS_LIST\n",
+    "from cltk.stop.latin import STOPS_LIST\n",
     "\n",
     "print(STOPS_LIST)"
    ]
@@ -1125,7 +1125,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixed ModuleNotFoundError while importing STOPS_LIST
```
from cltk.stop.latin.stops import STOPS_LIST
ModuleNotFoundError: No module named 'cltk.stop.latin.stops'; 'cltk.stop.latin' is not a package
```